### PR TITLE
Added flake.nix and shell.nix, addressing #76

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1727348695,
+        "narHash": "sha256-J+PeFKSDV+pHL7ukkfpVzCOO7mBSrrpJ3svwBFABbhI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1925c603f17fc89f4c8f6bf6f631a802ad85d784",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = "YAMLCord - Nix flake";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        devShell = pkgs.mkShell {
+          buildInputs = [
+            pkgs.nodejs
+            pkgs.pnpm
+            pkgs.biome 
+          ];
+          
+          shellHook = ''
+            export NODE_ENV=development
+            export IN_NIX_SHELL=1
+            export BIOME_BIN_PATH=$(which biome)
+            echo "You are now ready for development! Yay!"
+          '';
+        };
+      });
+}

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "url": "https://github.com/FancyStudioTeam/YAMLCord"
   },
   "scripts": {
-    "biome": "biome check --write --config-path=\"./biome.json\" .",
+    "biome": "BIOME_BINARY=${IN_NIX_SHELL:+$BIOME_BIN_PATH} npx @biomejs/biome check --write --config-path=\"./biome.json\"",
     "build": "tsc",
     "dev": "tsx --env-file=\".env\" --watch src/index.ts",
     "docs:build": "pnpm --filter=docs build",

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,16 @@
+{
+  pkgs ? import <nixpkgs> {}
+}: pkgs.mkShell {
+  buildInputs = [
+    pkgs.nodejs
+    pkgs.pnpm
+    pkgs.biome 
+  ];
+  
+  shellHook = ''
+    export NODE_ENV=development
+    export IN_NIX_SHELL=1
+    export BIOME_BIN=$(which biome)
+    echo "You are now ready for development! Yay!"
+  '';
+}


### PR DESCRIPTION
## Summary

Added a way for Nix and NixOS users to build, develop, and contribute in a reproducible manner. This resolves #76.

## Changes
```
+ Added shell.nix
+ Added flake.nix
~ Modified package.json to allow NixOS users to use Biome*
```
<sub>*This added because NixOS [cannot run dynamically linked executables/binaries](https://nix.dev/guides/faq#how-to-run-non-nix-executables) due to its nature.</sub>

## Additional notes

Need non-NixOS users to test whether `pnpm run biome` still works correctly.
All scripts (biome, build, dev, docs:build, docs:dev, docs:preview, prepare, test) work correctly on NixOS 24.11 (Vicuna)